### PR TITLE
changed HOST db setting comment.

### DIFF
--- a/OpenDataCatalog/settings.py
+++ b/OpenDataCatalog/settings.py
@@ -26,7 +26,7 @@ DATABASES = {
         'NAME': 'catalog',                      # Or path to database file if using sqlite3.
         'USER': 'catalog',                      # Not used with sqlite3.
         'PASSWORD': 'passw0rd',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
+        'HOST': '',                      # Set to 'localhost' for localhost. Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
     }
 }


### PR DESCRIPTION
Host parameter's comment said "set to empty string for localhost" but
this doesn't work: per the README, host needs to be set to 'localhost'
not left null.
