### PR TITLE
Make local styling easy.

### DIFF
--- a/OpenDataCatalog/local_settings.py.example
+++ b/OpenDataCatalog/local_settings.py.example
@@ -1,0 +1,50 @@
+import os
+
+
+SITE_ROOT = 'http://opendatacatalog.mycity.gov:8000'
+
+# Theme info
+LOCAL_STATICFILE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                               '../../ODC-overlay/static'))
+LOCAL_TEMPLATE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                             '../../ODC-overlay/templates'))
+
+# ReCatchpa stuff
+RECAPTCHA_PUBLIC_KEY = ''
+RECAPTCHA_PRIVATE_KEY = ''
+
+# Twitter stuff
+TWITTER_USER = None
+
+# AWS Credentials for Warehouse stuff
+AWS_ACCESS_KEY = None
+AWS_SECRET_KEY = None
+
+# Contacts
+mx_host = 'mycity.gov'
+ADMINS = (
+     ('OpenData Admins', 'admin@%s' % (mx_host,)),
+)
+CONTACT_EMAILS = ['admin@%s' % (mx_host,),]
+DEFAULT_FROM_EMAIL = 'OpenData Site <noreply@%s>'
+EMAIL_SUBJECT_PREFIX = '[OpenDataCatalog - MYCITY] '
+SERVER_EMAIL = 'OpenData Team <info@%s>' % (mx_host,)
+
+MANAGERS = (
+     ('OpenData Team', 'info@%s' % (mx_host,)),
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': 'catalog',                      # Or path to database file if using sqlite3.
+        'USER': 'catalog',                      # Not used with sqlite3.
+        'PASSWORD': 'passw0rd',                  # Not used with sqlite3.
+        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
+        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+    }
+}
+
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = 'insecure'
+

--- a/OpenDataCatalog/settings.py
+++ b/OpenDataCatalog/settings.py
@@ -1,10 +1,6 @@
 import os
 # Django settings for opendata project.
 
-SITE_ROOT = ""
-RECAPTCHA_PUBLIC_KEY = ""
-RECAPTCHA_PRIVATE_KEY = ""
-
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
@@ -82,14 +78,6 @@ STATIC_DATA = os.path.join(os.path.dirname(__file__), 'static/')
 #ADMIN_MEDIA_PREFIX = '/hidden/static/admin_media/'
 ADMIN_MEDIA_PREFIX = '/static/admin/'
 
-# Additional locations of static files
-STATICFILES_DIRS = (
-    # Put strings here, like "/home/html/static" or "C:/www/django/static".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    "/projects/OpenDataCatalog/opendata/static",
-)
-
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
@@ -98,18 +86,12 @@ STATICFILES_FINDERS = (
 #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
-# Make this unique, and don't share it with anybody.
-SECRET_KEY = 'insecure'
-
 ### Package settings
 ACCOUNT_ACTIVATION_DAYS = 7
-TWITTER_USER = None
 TWITTER_TIMEOUT = 6000
 THUMBNAIL_EXTENSION = 'png'
 PAGINATION_DEFAULT_WINDOW = 2
 ###
-
-LOGIN_URL = SITE_ROOT + "/accounts/login/"
 
 COMMENTS_APP = 'comments'
 
@@ -147,13 +129,6 @@ MIDDLEWARE_CLASSES = (
 )
 
 ROOT_URLCONF = 'urls'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    os.path.join(os.path.dirname(__file__), 'templates')
-)
 
 
 INSTALLED_APPS = (
@@ -212,3 +187,23 @@ try:
     from local_settings import *
 except Exception:
     pass
+
+# Additional locations of static files
+STATICFILES_DIRS = (
+    # Put strings here, like "/home/html/static" or "C:/www/django/static".
+    # Always use forward slashes, even on Windows.
+    # Don't forget to use absolute paths, not relative paths.
+    LOCAL_STATICFILE_DIR,
+    os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                 'opendata/static')),
+)
+
+TEMPLATE_DIRS = (
+    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
+    # Always use forward slashes, even on Windows.
+    # Don't forget to use absolute paths, not relative paths.
+    LOCAL_TEMPLATE_DIR,
+    os.path.join(os.path.dirname(__file__), 'templates')
+)
+
+LOGIN_URL = SITE_ROOT + "/accounts/login/"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ You can verify the connection with:
         psql opendata odc-user -h localhost
 
 ### Update settings
-Update the database settings in settings.py. You'll probably have to update "name", "user", "password", and "host". It should look similar to:
+
+Copy local_settings.py.example to local_settings.py
+
+Update the database settings in local_settings.py. You'll probably have to update "name", "user", "password", and "host". It should look similar to:
 
         DATABASES = {
            'default': {
@@ -78,6 +81,23 @@ To create the scheme we use django "syncdb" command
 We installed gunicorn as part of the installation process. All you need to do now is start it:
 
         gunicorn_django
+
+
+# Customizing your installation
+
+## Settings
+
+You should read OpenDataCatalog/local_settings.py for a list of configurable
+values, such as TWITTER_USER and SITE_ROOT.  Feel free to play with these
+settings as much as you want.
+
+## Style
+
+In local_settings.py you should specify a LOCAL_TEMPLATE_DIR that is the full
+path to your template location.  As you want to change the style, you copy
+files out of OpenDataCatalog/templates and into your local overly directory
+and make the changes there.  That way you can keep your repository in sync
+with the upstream more easily while still maintaining your own style.
 
 # Deploy to Heroku
 


### PR DESCRIPTION
This creates a local-settings.py.example where you can set static and template directories that get prefixed to the in-app values.  This lets you change style without cluttering up the application's directory (and thereby diverging from master).  This should help new localities set up quickly and easily, and keep all the users on a single branch!
