### PR TITLE
Azavea warehouse

### DIFF
--- a/OpenDataCatalog/opendata/forms.py
+++ b/OpenDataCatalog/opendata/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from models import UpdateFrequency, CoordSystem, UrlType, DataType
+from models import UpdateFrequency, CoordSystem, UrlType, DataType, Resource
 
 class SubmissionForm(forms.Form):
     dataset_name = forms.CharField(max_length=255, label="Data set, API or App name")
@@ -26,3 +26,13 @@ class SubmissionForm(forms.Form):
     certified = forms.BooleanField(required=False, label="", help_text="I am the copyright holder or have permission to release this data")
     terms = forms.BooleanField(label="", help_text="I have read and agree with the site's <a href='/terms/' target='_blank'>terms of use</a>")
     
+
+class ResourceForm(forms.ModelForm):
+    bucket = forms.CharField(max_length=80, widget=forms.HiddenInput)
+    key = forms.CharField(max_length=255, widget=forms.HiddenInput)
+    url = forms.CharField(max_length=255)
+
+    class Meta:
+        model = Resource
+        fields = ('name', 'is_published', 'description', 'short_description',
+                  'usage')

--- a/OpenDataCatalog/settings.py
+++ b/OpenDataCatalog/settings.py
@@ -178,6 +178,7 @@ INSTALLED_APPS = (
     'comments',
     'suggestions',
     'contest',
+    'warehouse',
     
 )
 

--- a/OpenDataCatalog/templates/warehouse/resource.html
+++ b/OpenDataCatalog/templates/warehouse/resource.html
@@ -1,0 +1,16 @@
+{% extends "template1.html" %}
+{% block title %} - Create Resource from Upload{% endblock %}
+
+{% block center_container %}
+  <div id="form_container" class="resource_form">
+
+    <h1>{{ url }} Uploaded</h1>
+    <h2>Now fill out this form to make a listing for this data</h2>
+
+    <form id="resource_from" action="{{ SITE_ROOT }}/warehouse/finalize/" method="post">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <input type="submit" value="Create Catalog Page">
+    </form>
+  </div>
+{% endblock %}

--- a/OpenDataCatalog/templates/warehouse/upload.html
+++ b/OpenDataCatalog/templates/warehouse/upload.html
@@ -1,0 +1,22 @@
+{% extends "template1.html" %}
+{% block title %} - Upload Data{% endblock %}
+
+{% block center_container %}
+  <div id="form_container" class="upload_form">
+    <form id="upload_from" action="https://{{ form.bucket_name }}.s3.amazonaws.com/" method="post" enctype="multipart/form-data">
+      <input type="hidden" name="key" value="{{ form.upload_name }}">
+      <input type="hidden" name="AWSAccessKeyId" value="{{ form.access_key }}"> 
+      <input type="hidden" name="acl" value="{{ form.acl }}"> 
+      <input type="hidden" name="success_action_redirect" value="{{ form.redirect_to }}">
+      <input type="hidden" name="policy" value="{{ form.policy }}">
+      <input type="hidden" name="signature" value="{{ form.signature }}">
+      <!-- input type="hidden" name="Content-Type" value="image/jpeg" -->
+      <!-- Include any additional input fields here -->
+
+      File to upload to S3: 
+      <input name="file" type="file"> 
+      <br> 
+      <input type="submit" value="Upload File to S3"> 
+    </form>
+  </div>
+{% endblock %}

--- a/OpenDataCatalog/urls.py
+++ b/OpenDataCatalog/urls.py
@@ -84,4 +84,7 @@ urlpatterns = patterns('',
         {'document_root': settings.STATIC_DATA}),
     (r'^media/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': settings.MEDIA_ROOT}),
+
+    # Comment this out if you don't want to warehouse data
+    (r'^warehouse/', include('warehouse.urls')),
 )

--- a/OpenDataCatalog/warehouse/admin.py
+++ b/OpenDataCatalog/warehouse/admin.py
@@ -1,0 +1,13 @@
+from django.contrib import admin
+
+from warehouse.models import Warehouse
+
+
+#class WarehouseAdmin(admin.ModelAdmin):
+#    list_display = ['group', 'bucket_name']
+#    search_fields = ['bucket_name']
+#    list_filter = ['bucket_name']
+
+
+admin.site.register(Warehouse) #, WarehouseAdmin)
+

--- a/OpenDataCatalog/warehouse/models.py
+++ b/OpenDataCatalog/warehouse/models.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.models import Group
+from django.db import models
+
+
+class Warehouse(models.Model):
+    group = models.ForeignKey(Group)
+    bucket_name = models.CharField(max_length=30)
+
+    class Meta:
+        permissions = (
+                ('upload', 'Can upload files to the data warehouse'),
+                )

--- a/OpenDataCatalog/warehouse/urls.py
+++ b/OpenDataCatalog/warehouse/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls.defaults import patterns
+
+urlpatterns = patterns('',
+        (r'upload/$', 'warehouse.views.upload'),
+        (r'postback/$', 'warehouse.views.postback'),
+        (r'finalize/$', 'warehouse.views.finalize'),
+)

--- a/OpenDataCatalog/warehouse/views.py
+++ b/OpenDataCatalog/warehouse/views.py
@@ -1,0 +1,125 @@
+import base64
+import datetime
+import hmac
+import sha
+import simplejson
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.models import User, Group
+from django.shortcuts import render_to_response, redirect
+from django.template import RequestContext
+#from django.http import HttpResponseRedirect
+
+from opendata.forms import ResourceForm
+from opendata.models import Url, UrlType
+from models import Warehouse
+
+
+class FormGenerator(object):
+    def __init__(self, user):
+        self.user = user
+        self.policy_document = None
+        self._find_warehouse()
+
+    def acl(self):
+        return 'public-read'
+
+    def redirect_to(self):
+        return '%s/warehouse/postback/' % (settings.SITE_ROOT,)
+
+    def bucket_name(self):
+        return self.warehouse.bucket_name
+
+    def upload_name(self):
+        # TODO(todd): maybe do something else here like timestamp?
+        return '${filename}'
+
+    def access_key(self):
+        return settings.AWS_ACCESS_KEY
+
+    def policy(self):
+        self._generate_policy()
+        return self.policy_document
+
+    def signature(self):
+        self._generate_policy()
+        signer = hmac.new(settings.AWS_SECRET_KEY, self.policy_document, sha)
+        return base64.b64encode(signer.digest())
+
+    def _generate_policy(self):
+        if self.policy_document:
+            return
+        # S3 wants something that isn't quite isoformat
+        expiry = datetime.datetime.now() + datetime.timedelta(days=3)
+        values = {'expiration': '%sZ' % (expiry.isoformat(),),
+                  'conditions': [
+                      {'bucket': self.bucket_name()},
+                      {'acl': self.acl()},
+                      {'success_action_redirect': self.redirect_to()},
+                      ['starts-with', '$key', '']]}
+                      #['starts-with', '$Content-Type', '']]}
+        self.policy_document = base64.b64encode(simplejson.dumps(values))
+
+    def _find_warehouse(self):
+        groups = self.user.groups.all()
+        self.warehouse = None
+        for group in groups:
+            for warehouse in group.warehouse_set.all():
+                if self.warehouse:
+                    raise Exception, 'You have too many warehouse associations'
+                else:
+                    self.warehouse = warehouse
+        if not self.warehouse:
+            raise Exception, 'You do not have a warehouse association'
+
+
+@permission_required('warehouse.upload')
+@permission_required('opendata.add_resource')
+def upload(request):
+    # TODO(todd): make sure they have upload access warehouse.upload
+    user = User.objects.get(username=request.user)
+    form = FormGenerator(user)
+    return render_to_response('warehouse/upload.html', {'form': form},
+		              context_instance=RequestContext(request))
+
+
+@permission_required('warehouse.upload')
+@permission_required('opendata.add_resource')
+def postback(request):
+    bucket = request.GET['bucket']
+    key = request.GET['key']
+    url = 'https://%s.s3.amazonaws.com/%s' % (bucket, key)
+    form = ResourceForm(initial={'key': key, 'bucket': bucket, 'url': url})
+    return render_to_response('warehouse/resource.html',
+            {'form': form, 'url': url},
+		    context_instance=RequestContext(request))
+
+
+@permission_required('warehouse.upload')
+@permission_required('opendata.add_resource')
+def finalize(request):
+    form = ResourceForm(request.POST)
+    user = User.objects.get(username=request.user)
+    warehouse = Warehouse.objects.get(
+                        bucket_name=form.data['bucket'])
+    group = warehouse.group
+    form.instance.organization = group.name
+    form.instance.created_by = user
+    form.instance.last_updated_by = user
+    form.instance.created = datetime.datetime.utcnow()
+    if form.is_valid():
+        resource = form.save()
+        url_type = UrlType.objects.get(url_type='Data')
+        url = Url()
+        url.resource = resource
+        url.url_type = url_type
+        url.url = form.data['url']
+        url.url_label = form.data['url']
+        url.save()
+        return redirect('%s/opendata/resource/%i' % (settings.SITE_ROOT,
+                                                     resource.pk))
+    else:
+        return render_to_response('warehouse/resource.html',
+                {'form': form, 'url': form.data['url']},
+                context_instance=RequestContext(request))


### PR DESCRIPTION
   Add data warehousing.

```
Be sure to set AWS_ACCESS_KEY and AWS_SECRET_KEY in local_settings.py.

When navigating to /warehouse, if your group has a data warehosue (and
corresponding s3 bucket) you will have a file upload form that posts
directly to s3.  Upon completion you are redirected back you the catalog
site where you fill out the rest of the information for the resource.  A
data url is automatically created that points to your data set.
```
