### PR TITLE
Fixed URL of "Link to This Idea" button

### DIFF
--- a/OpenDataCatalog/templates/ideas.html
+++ b/OpenDataCatalog/templates/ideas.html
@@ -75,7 +75,7 @@
           </ul>
 
 				<div id="idea_footer">
-					<div class="idea_button"><a href="{{SITE_ROOT}}/{{idea.get_absolute_url}}" class="button">Link to this idea</a></div>
+					<div class="idea_button"><a href="{{SITE_ROOT}}{{idea.get_absolute_url}}" class="button">Link to this idea</a></div>
 					<div class="idea_date">Posted: <strong>{{idea.created_by_date|date:"M d, Y"}}</strong></div>
           <div class="clear"></div>
 				</div>


### PR DESCRIPTION
There was a '/' between {{SITE_ROOT}} and {{idea.get_absolute_url}} resulting in //idea/5/etcetc instead of /idea/5/etcetc
