### PR TITLE
bump pycsw version

### DIFF
--- a/OpenDataCatalog/catalog/views.py
+++ b/OpenDataCatalog/catalog/views.py
@@ -14,7 +14,7 @@ CONFIGURATION = {
         'language': 'en-US',
         'maxrecords': '10',
         # 'pretty_print': 'true',
-        'profiles': 'apiso,dif,fgdc,atom,ebrim',
+        'profiles': 'apiso,ebrim',
     },
     'repository': {
         'source': 'odc',

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ simplejson==2.5.0
 sorl-thumbnail==3.2.5
 twitter==1.7.2
 wsgiref==0.1.2
-pycsw==1.4.1
+pycsw==1.6.0


### PR DESCRIPTION
cc @ahinz

This PR updates pycsw to 1.6.0, and removes atom/dif/fgdc from the pycsw configuration (these are now enabled by default).
