### PR TITLE
Fixing file extension logic error

### DIFF
--- a/OpenDataCatalog/opendata/models.py
+++ b/OpenDataCatalog/opendata/models.py
@@ -276,7 +276,7 @@ class UrlImage(models.Model):
         while os.path.exists(test_path):
            extra += 1
            test_path = os.path.join(settings.MEDIA_ROOT, 'url_images', str(instance.url_id), fsplit[0] + '_' + str(extra) + '.' +  fsplit[1])
-        path = os.path.join('url_images', str(instance.url_id), fsplit[0] + '_' + str(extra) + '.' + fsplit[1])
+        path = os.path.join('url_images', str(instance.url_id), fsplit[0] + '_' + str(extra) + '.' + fsplit[-1])
         return path
         
     url = models.ForeignKey(Url)
@@ -322,7 +322,7 @@ class IdeaImage(models.Model):
         while os.path.exists(test_path):
            extra += 1
            test_path = os.path.join(settings.MEDIA_ROOT, 'idea_images', str(instance.idea_id), fsplit[0] + '_' + str(extra) + '.' +  fsplit[1])
-        path = os.path.join('idea_images', str(instance.idea_id), fsplit[0] + '_' + str(extra) + '.' + fsplit[1])
+        path = os.path.join('idea_images', str(instance.idea_id), fsplit[0] + '_' + str(extra) + '.' + fsplit[-1])
         return path
 
     idea = models.ForeignKey(Idea)


### PR DESCRIPTION
The pythonic way to select the last segment of a file name is using the -1 index. Fixes for images with names like Screen Shot 2013-09-05 at 1.19.09 PM.png
