### PR TITLE
Instead of pulling raw POST data, use the form's cleaned_data dict

### DIFF
--- a/OpenDataCatalog/contest/views.py
+++ b/OpenDataCatalog/contest/views.py
@@ -46,18 +46,18 @@ def add_entry(request, contest_id=1):
             data = {
                 #"submitter": request.user.username,
                 "submit_date": datetime.now(),
-                "org_name": request.POST.get("org_name"),
-                "org_url": request.POST.get("org_url"),
-                "contact_person": request.POST.get("contact_person"),
-                "contact_phone": request.POST.get("contact_phone"),
-                "contact_email": request.POST.get("contact_email"),
-                "data_set": request.POST.get("data_set"),
-                "data_use": request.POST.get("data_use"),
-                "data_mission": request.POST.get("data_mission")
+                "org_name": form.cleaned_data.get("org_name"),
+                "org_url": form.cleaned_data.get("org_url"),
+                "contact_person": form.cleaned_data.get("contact_person"),
+                "contact_phone": form.cleaned_data.get("contact_phone"),
+                "contact_email": form.cleaned_data.get("contact_email"),
+                "data_set": form.cleaned_data.get("data_set"),
+                "data_use": form.cleaned_data.get("data_use"),
+                "data_mission": form.cleaned_data.get("data_mission")
             }
 
             subject = 'OpenDataPhilly - Contest Submission'
-            user_email = request.POST.get("contact_email")
+            user_email = form.cleaned_data.get("contact_email")
             text_content = render_to_string('contest/submit_email.txt', data)
             text_content_copy = render_to_string('contest/submit_email_copy.txt', data)
             mail_managers(subject, text_content)


### PR DESCRIPTION
Despite the fact that the form is technically valid, we should use the data from the form's cleaned_data, in the case that there have been modifications or removals.
