### PR TITLE
Update gunicorn version to 0.14.3 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-pagination==1.0.7
 django-ratings==0.3.6
 hg+https://bitbucket.org/ubernostrum/django-registration#egg=django-registration
 django-sorting==0.1
-gunicorn==0.14.2
+gunicorn==0.14.3
 httplib2==0.7.4
 oauth2==1.5.211
 psycopg2==2.5


### PR DESCRIPTION
After running gunicorn_django, I got an error following:

2013-10-06 16:47:38 [12059] [INFO] Starting gunicorn 0.14.2
2013-10-06 16:47:38 [12059] [INFO] Listening at: http://10.0.2.15:8000 (12059)
2013-10-06 16:47:38 [12059] [INFO] Using worker: sync
2013-10-06 16:47:38 [12062] [INFO] Booting worker with pid: 12062
2013-10-06 16:47:40 [12062] [ERROR] Exception in worker process:
Traceback (most recent call last):
File "/var/lib/postgresql/opendatacatalog/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 453, in spawn_worker
worker.init_process()
File "/var/lib/postgresql/opendatacatalog/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 99, in init_process
self.wsgi = self.app.wsgi()
File "/var/lib/postgresql/opendatacatalog/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 101, in wsgi
self.callable = self.load()
File "/var/lib/postgresql/opendatacatalog/local/lib/python2.7/site-packages/gunicorn/app/djangoapp.py", line 87, in load
mod = util.import_module("gunicorn.app.django_wsgi")
File "/usr/lib/python2.7/importlib/init.py", line 37, in import_module
import(name)
File "/var/lib/postgresql/opendatacatalog/local/lib/python2.7/site-packages/gunicorn/app/django_wsgi.py", line 20, in 
from django.core.servers.basehttp import AdminMediaHandler
ImportError: cannot import name AdminMediaHandler
2013-10-06 16:47:40 [12062] [INFO] Worker exiting (pid: 12062)
2013-10-06 16:47:41 [12059] [INFO] Shutting down: Master
2013-10-06 16:47:41 [12059] [INFO] Reason: Worker failed to boot.

This is caused by AdminMediaHandler has been removed in Django 1.5.1. and this issue was fixed by #Issue333 (benoitc/gunicorn#333 ), and then This fix has been released as gunicorn 0.14.3.

So, I updated requirement.txt, tested it out on Ubuntu 12.04 and made sure it works well.
